### PR TITLE
Pin stdweb version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ glenum = { git = "https://github.com/oussama/glenum-rs" }
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-stdweb = { git = "https://github.com/koute/stdweb", optional = true }
+stdweb = { version = "0.4.6", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gl = "0.9"


### PR DESCRIPTION
Using the git repo as the source for stdweb dependency causes issue when building with `cargo web`. Pinning to 0.4.6 resolves the issue however.